### PR TITLE
Made the google module version stick to be terraform 0.11 compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+.terraform*
+*.tfstate
+*.tfstate.backup

--- a/README.md
+++ b/README.md
@@ -44,3 +44,5 @@ priv-cluster
 The terraform files for the VPC and the GKE cluster are using the following [Google maintained modules](https://github.com/terraform-google-modules). 
 
 
+## Terraform version
+Tested with Terraform v0.11.*. Incompatible with Terraform 0.12.

--- a/network/main.tf
+++ b/network/main.tf
@@ -1,4 +1,5 @@
 module "gke-no-internet-network" {
+  version = "~> 0.8.0"
   source = "terraform-google-modules/network/google"
 
   project_id                             = "${var.project_id}"

--- a/priv-cluster/main.tf
+++ b/priv-cluster/main.tf
@@ -15,7 +15,8 @@ provider "google-beta" {
 }
 
 module "private_gke_cluster" {
-  source                  = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/private-cluster"
+  source                  = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
+  version		  = "~> 3.0.0"
   project_id              = "${var.project_id}"
   name                    = "${var.gke_cluster}"
   regional                = false


### PR DESCRIPTION
Terraform 0.12 doesn't work.
Terraform 0.11 didn't work without these changes.